### PR TITLE
Deleted call to removeItem after being processed

### DIFF
--- a/src/whenInViewport.js
+++ b/src/whenInViewport.js
@@ -186,7 +186,7 @@
 
             if (scrollOffset + windowHeight >= item.topOffset - item.threshold) {
 
-                this.removeItem(item);
+                //this.removeItem(item);
                 item.callback.call(item.context || window, item.element);
 
             }


### PR DESCRIPTION
I used your plugin on a vue.js application where it was being used multiple times in the same window.

E.g imagine a list of results. Each result had an element inside that was using whenInViewport to determine if it had been scrolled past or not.

I had a lot of issues because it seems that whenever an item was scrolled past, it was removed so if the user scrolled back up, then down again, it wouldn't be detected. (Or may be there was another issue, I can't remember, but there definitely was something)

Removing this line fixed the issue for me. I've been using my fixed version for a year or so, just came across this and thought I should contribute.